### PR TITLE
fix for the inherit error - TypeError: The super constructor to inher…

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -196,7 +196,7 @@ var Connection = function(options){
    */
   this.ready = false;
 };
-util.inherits(Connection, process.EventEmitter);
+util.inherits(Connection, request('events'));
 
 /**
  * Connects to the cassandra cluster

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -196,7 +196,7 @@ var Connection = function(options){
    */
   this.ready = false;
 };
-util.inherits(Connection, request('events'));
+util.inherits(Connection, require('events').EventEmitter);
 
 /**
  * Connects to the cassandra cluster

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -71,7 +71,7 @@ var Pool = function(options){
     throw(new Error('HelenusError: Invalid hosts supplied for connection pool'));
   }
 };
-util.inherits(Pool, require('events'));
+util.inherits(Pool, require('events').EventEmitter);
 
 /**
  * Connects to each of the servers in the connection pool

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -71,7 +71,7 @@ var Pool = function(options){
     throw(new Error('HelenusError: Invalid hosts supplied for connection pool'));
   }
 };
-util.inherits(Pool, process.EventEmitter);
+util.inherits(Pool, require('events'));
 
 /**
  * Connects to each of the servers in the connection pool


### PR DESCRIPTION
Fix for errors like these while running chatous server ->
Caught exception: TypeError: The super constructor to "inherits" must not be null or undefined
TypeError: The super constructor to "inherits" must not be null or undefined
    at Object.inherits (util.js:973:11)
    at Object.<anonymous> (/usr/src/app/node_modules/helenus/lib/pool.js:74:6)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Module.require (module.js:568:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/usr/src/app/node_modules/helenus/lib/helenus.js:26:26)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Module.require (module.js:568:17)